### PR TITLE
Move org.gnome.Platform to v47 & ungoogled-chromium-bin to v130.0.6723.58

### DIFF
--- a/com.mudeprolinux.whakarere.json
+++ b/com.mudeprolinux.whakarere.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.mudeprolinux.whakarere",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "45",
+    "runtime-version" : "47",
     "sdk" : "org.gnome.Sdk",
     "command" : "whakarere",
     "finish-args" : [

--- a/com.mudeprolinux.whakarere.yml
+++ b/com.mudeprolinux.whakarere.yml
@@ -1,6 +1,6 @@
 app-id: com.mudeprolinux.whakarere
 runtime: org.gnome.Platform
-runtime-version: '45'
+runtime-version: '47'
 sdk: org.gnome.Sdk
 command: whakarere
 


### PR DESCRIPTION
As org.gnome.Platform v45 is EOL it should be updated to v47