### PR TITLE
Fixes for non-sandboxed environments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,14 @@ fn main() -> anyhow::Result<()> {
     app.connect_startup(move |app| {
         adw::init().expect("Failed to initialize Libadwaita");
 
+        let _ = RUNTIME.block_on(async move {
+            ashpd::register_host_app("io.github.tobagin.karere".parse().unwrap()).await
+                .map_err(|e| {
+                    log::error!("Failed to register app with portal: {}", e);
+                    e
+                })
+        });
+
         // Sync Autostart Status
         // We ensure the portal permission matches the user preference on every startup.
         // We ensure the portal permission matches the user preference on every startup.
@@ -91,6 +99,7 @@ fn main() -> anyhow::Result<()> {
              RUNTIME.spawn(async move {
                 let request_future = ashpd::desktop::background::Background::request()
                     .reason("Syncing autostart preference")
+                    .command(if ashpd::is_sandboxed() { vec![] } else { vec!["karere"] })
                     .auto_start(enabled)
                     .send();
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -145,7 +145,7 @@ mod imp {
                 .and_then(|app| app.application_id())
                 .map(|s| s.to_string())
                 .or_else(|| std::env::var("FLATPAK_ID").ok())
-                .unwrap_or_default();
+                .unwrap_or("io.github.tobagin.karere".to_string());
 
             if app_id.contains("Dev") || app_id.contains("Devel") {
                  obj.add_css_class("devel");


### PR DESCRIPTION
- Set application id using ashpd::register_host_app (register_host_app is a no-op in sandboxed environments). Note that this needs to happen before using any portals.
- Set the command to run for autostart in non-sandboxed environments.
- Set the correct GSettings schema in non-sandboxed environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed application identification fallback to ensure proper settings and UI styling behavior
  * Enhanced autostart functionality with improved support for sandboxed environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->