### PR TITLE
Fix #147: load_uri must wait for web_view

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -2187,7 +2187,14 @@ mod imp {
                 }
             });
 
-            web_view.load_uri("https://web.whatsapp.com");
+            // Make sure web_view has loaded first
+            if web_view.is_realized() {
+                web_view.load_uri("https://web.whatsapp.com");
+            } else {
+                web_view.connect_realize(|wv| {
+                    wv.load_uri("https://web.whatsapp.com");
+                });
+            }
             web_view
         }
 


### PR DESCRIPTION
Closes #147 
- Fixed race condition where `load_uri` could sometimes be executed before `web_view` has loaded.

Working dev build vs current release build
<img width="4014" height="1524" alt="Screenshot_20260512_232430" src="https://github.com/user-attachments/assets/83a90b04-1bc3-496d-89a8-0dcdc70f8e5f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced WhatsApp Web initialization to ensure content loads reliably when the application starts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tobagin/karere/pull/148)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->